### PR TITLE
Fix: Remove 'edit_uri' to hide footer text

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,5 @@
 site_name: Presto Workshop - Getting Started with Presto
 repo_url: https://github.com/testing-company/test-repo
-edit_uri: edit/main/docs/
 
 theme:
   name: material


### PR DESCRIPTION
Removes the `edit_uri` setting from `mkdocs.yml`.
This change is intended to remove the "This site is open source. Improve this page." footer that is often generated by the Material for MkDocs theme when `edit_uri` is present.