### PR TITLE
Fix: Grant write permissions to GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions: # Add this block
+      contents: write # Grant write permission for repository contents
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
The previous deployment failed due to the GitHub Actions workflow lacking write permissions to push the built site to the 'gh-pages' branch.

This commit updates the '.github/workflows/ci.yml' file to include 'permissions: contents: write' for the 'deploy' job. This allows the action to successfully push to the repository.