### PR TITLE
Fix: Set site_url in mkdocs.yml for subdirectory hosting

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: My Awesome Blog
+site_url: https://xjasonliu.github.io/AI4Business/ # Add this line
 theme:
   name: material
 nav:


### PR DESCRIPTION
The blog was returning a 404 error on the homepage because asset paths and links were not being generated correctly for subdirectory hosting (e.g., /AI4Business/).

This commit updates mkdocs.yml to include:
site_url: https://xjasonliu.github.io/AI4Business/

This ensures that MkDocs generates all URLs relative to this base path, which should resolve the 404 errors.