### PR TITLE
Fix: Set use_directory_urls to false in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: My Awesome Blog
 site_url: https://xjasonliu.github.io/AI4Business/ # Add this line
+use_directory_urls: false # Add this line
 theme:
   name: material
 nav:


### PR DESCRIPTION
The blog continued to show a 404 error on the homepage even after setting the site_url. This change attempts to resolve the issue by setting 'use_directory_urls: false' in mkdocs.yml.

This modification alters MkDocs' URL generation strategy from 'example.com/page/' to 'example.com/page.html', which can improve compatibility with GitHub Pages' file serving behavior, especially for index files in subdirectories.