### PR TITLE
Initial setup for AI4Business Blog

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,5 @@
-# About the workshop
+# Welcome to AI4Business Blogs
 
-Content coming soon.
+This is the home page of the AI4Business blog. You'll find articles and updates on various topics related to AI in business here.
+
+Navigate to the [Posts](posts/README.md) section to read the latest articles.

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,0 +1,5 @@
+# About
+
+This page provides information about the AI4Business blog and its author.
+
+(More details to be added here later.)

--- a/docs/introduction/README.md
+++ b/docs/introduction/README.md
@@ -1,3 +1,0 @@
-# Introduction
-
-Content coming soon.

--- a/docs/lab-1/README.md
+++ b/docs/lab-1/README.md
@@ -1,3 +1,0 @@
-# Lab 1. Set up Presto
-
-Content coming soon.

--- a/docs/lab-2/README.md
+++ b/docs/lab-2/README.md
@@ -1,3 +1,0 @@
-# Lab 2. Data Sources
-
-Content coming soon.

--- a/docs/lab-3/README.md
+++ b/docs/lab-3/README.md
@@ -1,3 +1,0 @@
-# Lab 3. Add Catalogs
-
-Content coming soon.

--- a/docs/lab-4/README.md
+++ b/docs/lab-4/README.md
@@ -1,3 +1,0 @@
-# Lab 4. Data Visualization
-
-Content coming soon.

--- a/docs/posts/README.md
+++ b/docs/posts/README.md
@@ -1,0 +1,7 @@
+# Blog Posts
+
+This section contains all the blog posts.
+
+## Latest Posts
+
+*   (No posts yet)

--- a/docs/prerequisite/README.md
+++ b/docs/prerequisite/README.md
@@ -1,3 +1,0 @@
-# Prerequisite
-
-Content coming soon.

--- a/docs/resources/CONTRIBUTORS.md
+++ b/docs/resources/CONTRIBUTORS.md
@@ -1,3 +1,0 @@
-# Contributors
-
-Content coming soon.

--- a/docs/resources/HEML.md
+++ b/docs/resources/HEML.md
@@ -1,3 +1,0 @@
-# Helm
-
-Content coming soon.

--- a/docs/resources/RESOURCES.md
+++ b/docs/resources/RESOURCES.md
@@ -1,3 +1,0 @@
-# Additional Resources
-
-Content coming soon.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,34 +1,24 @@
 # Project information
-site_name: AI4Business Blog
+site_name: "AI4Business Blogs"
 site_url: https://xjasonliu.github.io/AI4Business/
-site_author: xjasonliu # Preserving this for now, can be changed later
-use_directory_urls: false
+site_author: "xjasonliu"
+use_directory_urls: true
 
 # Repository
-repo_name: xjasonliu/AI4Business
-repo_url: https://github.com/xjasonliu/AI4Business/
-edit_uri: edit/main/docs
+repo_name: "xjasonliu/AI4Business"
+repo_url: "https://github.com/xjasonliu/AI4Business/"
+edit_uri: edit/main/docs/
 
 # Navigation
 nav:
-  - Welcome:
-    - About the workshop: README.md
-  - Workshop:
-    - Prerequisite: prerequisite/README.md
-    - Introduction: introduction/README.md
-    - Lab 1. Set up Presto: lab-1/README.md
-    - Lab 2. Data Sources: lab-2/README.md
-    - Lab 3. Add Catalogs: lab-3/README.md
-    - Lab 4. Data Visualization : lab-4/README.md
-  - References:
-    - Helm: resources/HEML.md
-    - Additional Resources: resources/RESOURCES.md
-    - Contributors: resources/CONTRIBUTORS.md
+  - Home: README.md
+  - Posts: posts/README.md
+  - About: about.md
 
 ## DO NOT CHANGE BELOW THIS LINE
 
 # Copyright
-copyright: Copyright &copy; 2023 IBM Developer # Preserving this
+copyright: "Copyright &copy; 2023 xjasonliu"
 
 # Theme
 theme: # Preserving theme settings
@@ -57,16 +47,16 @@ plugins: # Preserving plugins
 # Customization
 extra: # Preserving extra
   social:
-    - icon: fontawesome/brands/github
-      link: https://github.com/ibm # This might need update later
-    - icon: fontawesome/brands/twitter
-      link: https://twitter.com/ibmdeveloper # This might need update later
-    - icon: fontawesome/brands/linkedin
-      link: https://www.linkedin.com/company/ibm/ # This might need update later
-    - icon: fontawesome/brands/youtube
-      link: https://www.youtube.com/user/developerworks # This might need update later
-    - icon: fontawesome/brands/dev
-      link: https://dev.to/ibmdeveloper # This might need update later
+    # - icon: fontawesome/brands/github
+    #   link: https://github.com/ibm # This might need update later
+    # - icon: fontawesome/brands/twitter
+    #   link: https://twitter.com/ibmdeveloper # This might need update later
+    # - icon: fontawesome/brands/linkedin
+    #   link: https://www.linkedin.com/company/ibm/ # This might need update later
+    # - icon: fontawesome/brands/youtube
+    #   link: https://www.youtube.com/user/developerworks # This might need update later
+    # - icon: fontawesome/brands/dev
+    #   link: https://dev.to/ibmdeveloper # This might need update later
 
 # Extensions
 markdown_extensions: # Preserving extensions


### PR DESCRIPTION
This commit clears the previous workshop content and establishes a new blog structure using MyDocs with the Material theme.

Key changes:
- Cleared files and folders in the `docs/` directory, preserving only `docs/README.md`.
- Updated `mkdocs.yml`:
    - Set `site_name` to "AI4Business Blogs".
    - Set `site_author` to "xjasonliu".
    - Updated `repo_name` and `repo_url` to point to `xjasonliu/AI4Business`.
    - Implemented a new navigation structure: Home, Posts, About.
    - Set `use_directory_urls` to `true`.
    - Updated copyright information.
    - Commented out placeholder IBM social links.
- Created initial content files:
    - `docs/README.md` as the main landing page.
    - `docs/posts/README.md` as the placeholder for blog post listings.
    - `docs/about.md` as the placeholder for the About page.